### PR TITLE
UCNF: Change vpp memif setup to use interrupt mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,8 @@ e2e-kind-test: &e2e-kind-test
     - run:
         name: Run vl3 test
         command: |
-          docker exec -e VL3_IMGTAG=${CIRCLE_SHA1} -t vl3-run bash -c "/go/run_vl3.sh"
+
+          docker exec -e NSE_HUB=${ORG} -e NSE_TAG=${CIRCLE_SHA1} -t vl3-run bash -c "/go/run_vl3.sh"
     - run:
         name: Dump KinD Cluster state
         when: always
@@ -160,17 +161,17 @@ jobs:
           name: Build vL3 docker image
           working_directory: /go/src/github.com/cisco-app-networking/nsm-nse
           command: |
-            ORG=tiswanso TAG=${CIRCLE_SHA1} make docker-vl3
+            ORG=${ORG} TAG=${CIRCLE_SHA1} make docker-vl3
       - run:
           name: Build ucnf-kiknos docker image
           working_directory: /go/src/github.com/cisco-app-networking/nsm-nse
           command: |
-            ORG=tiswanso TAG=${CIRCLE_SHA1} make docker-ucnf-kiknos-vppagent-build 
+            ORG=${ORG} TAG=${CIRCLE_SHA1} make docker-ucnf-kiknos-vppagent-build 
       - run:
           name: Save docker images
           working_directory: /go/src/github.com/cisco-app-networking/nsm-nse
           command: |
-            images_to_save+=("tiswanso/vl3_ucnf-nse:${CIRCLE_SHA1}" "tiswanso/ucnf-kiknos-vppagent:${CIRCLE_SHA1}")
+            images_to_save+=("${ORG}/vl3_ucnf-nse:${CIRCLE_SHA1}" "${ORG}/ucnf-kiknos-vppagent:${CIRCLE_SHA1}")
             mkdir -p _save
             docker save "${images_to_save[@]}" >_save/images.tar
       - persist_to_workspace:

--- a/build/ci/runner/run_vl3.sh
+++ b/build/ci/runner/run_vl3.sh
@@ -7,12 +7,15 @@
 #
 # env:
 #   KUBECONFDIR -- dir with 2 kubeconfig files, default = /etc/kubeconfigs
-#   VL3_IMGTAG -- image tag for vL3 NSE container
+#   NSE_HUB -- image repo for NSE container
+#   NSE_TAG -- image tag for vL3 NSE container
 #
 
 KUBECONFDIR=${KUBECONFDIR:-/etc/kubeconfigs}
 SERVICENAME=ucnf
 NSE_NS=${NSE_NS:-default}
+NSE_HUB=${NSE_HUB:-"tiswanso"}
+NSE_TAG=${NSE_TAG:-"latest"}
 
 kubeconfs=$(ls ${KUBECONFDIR})
 
@@ -52,26 +55,26 @@ clus1_IP=$(kubectl get node --kubeconfig ${KCONF1} --selector='node-role.kuberne
 clus2_IP=$(kubectl get node --kubeconfig ${KCONF2} --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
 
 echo "# **** Install vL3 in cluster 1 (point at cluster2's IP=${clus2_IP})"
-REMOTE_IP=${clus2_IP} KCONF=${KCONF1} TAG=${VL3_IMGTAG} NAMESPACE=${NSE_NS} scripts/vl3/vl3_interdomain.sh --ipamOctet=22 --serviceName=${SERVICENAME}
+REMOTE_IP=${clus2_IP} KCONF=${KCONF1} NSE_HUB=${NSE_HUB} NSE_TAG=${NSE_TAG} NAMESPACE=${NSE_NS} scripts/vl3/vl3_interdomain.sh --ipamOctet=22 --serviceName=${SERVICENAME}
 
 kubectl describe deployment vl3-nse-${SERVICENAME} -n ${NSE_NS} --kubeconfig ${KCONF1}
 kubectl get pods -n ${NSE_NS} --kubeconfig ${KCONF1}
 #kubectl get pods -n nsm-system --kubeconfig ${KCONF1}
 
 echo "# **** Install vL3 in cluster 2 (point at cluster1's IP=${clus1_IP})"
-REMOTE_IP=${clus1_IP} KCONF=${KCONF2} TAG=${VL3_IMGTAG} NAMESPACE=${NSE_NS} scripts/vl3/vl3_interdomain.sh --ipamOctet=33 --serviceName=${SERVICENAME}
+REMOTE_IP=${clus1_IP} KCONF=${KCONF2} NSE_HUB=${NSE_HUB} NSE_TAG=${NSE_TAG} NAMESPACE=${NSE_NS} scripts/vl3/vl3_interdomain.sh --ipamOctet=33 --serviceName=${SERVICENAME}
 
 kubectl describe deployment vl3-nse-${SERVICENAME} -n ${NSE_NS} --kubeconfig ${KCONF2}
 kubectl get pods -n ${NSE_NS} --kubeconfig ${KCONF2}
 #kubectl get pods -n nsm-system --kubeconfig ${KCONF2}
 
 echo "# **** Install helloworld on cluster 1"
-helm template deployments/helm/vl3_hello --set nsm.serviceName=${SERVICE_NAME} --set replicaCount=1 | kubectl apply --kubeconfig ${KCONF1} -f -
+helm template deployments/helm/vl3_hello --set nsm.serviceName=${SERVICENAME} --set replicaCount=1 | kubectl apply --kubeconfig ${KCONF1} -f -
 
 sleep 60
 
 echo "# **** Install helloworld on cluster 2"
-helm template deployments/helm/vl3_hello --set nsm.serviceName=${SERVICE_NAME} --set replicaCount=1 | kubectl apply --kubeconfig ${KCONF2} -f -
+helm template deployments/helm/vl3_hello --set nsm.serviceName=${SERVICENAME} --set replicaCount=1 | kubectl apply --kubeconfig ${KCONF2} -f -
 
 echo "# **** wait on helloworld pods to come up"
 kubectl wait --kubeconfig ${KCONF1} --timeout=600s --for condition=Ready -l app=helloworld pod

--- a/build/ci/runner/run_vl3.sh
+++ b/build/ci/runner/run_vl3.sh
@@ -12,6 +12,7 @@
 
 KUBECONFDIR=${KUBECONFDIR:-/etc/kubeconfigs}
 SERVICENAME=ucnf
+NSE_NS=${NSE_NS:-default}
 
 kubeconfs=$(ls ${KUBECONFDIR})
 
@@ -51,17 +52,17 @@ clus1_IP=$(kubectl get node --kubeconfig ${KCONF1} --selector='node-role.kuberne
 clus2_IP=$(kubectl get node --kubeconfig ${KCONF2} --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
 
 echo "# **** Install vL3 in cluster 1 (point at cluster2's IP=${clus2_IP})"
-REMOTE_IP=${clus2_IP} KCONF=${KCONF1} TAG=${VL3_IMGTAG} scripts/vl3/vl3_interdomain.sh --ipamOctet=22 --serviceName=${SERVICENAME}
+REMOTE_IP=${clus2_IP} KCONF=${KCONF1} TAG=${VL3_IMGTAG} NAMESPACE=${NSE_NS} scripts/vl3/vl3_interdomain.sh --ipamOctet=22 --serviceName=${SERVICENAME}
 
-kubectl describe deployment vl3-nse-${SERVICENAME} --kubeconfig ${KCONF1}
-kubectl get pods --kubeconfig ${KCONF1}
+kubectl describe deployment vl3-nse-${SERVICENAME} -n ${NSE_NS} --kubeconfig ${KCONF1}
+kubectl get pods -n ${NSE_NS} --kubeconfig ${KCONF1}
 #kubectl get pods -n nsm-system --kubeconfig ${KCONF1}
 
 echo "# **** Install vL3 in cluster 2 (point at cluster1's IP=${clus1_IP})"
-REMOTE_IP=${clus1_IP} KCONF=${KCONF2} TAG=${VL3_IMGTAG} scripts/vl3/vl3_interdomain.sh --ipamOctet=33 --serviceName=${SERVICENAME}
+REMOTE_IP=${clus1_IP} KCONF=${KCONF2} TAG=${VL3_IMGTAG} NAMESPACE=${NSE_NS} scripts/vl3/vl3_interdomain.sh --ipamOctet=33 --serviceName=${SERVICENAME}
 
-kubectl describe deployment vl3-nse-${SERVICENAME} --kubeconfig ${KCONF2}
-kubectl get pods --kubeconfig ${KCONF2}
+kubectl describe deployment vl3-nse-${SERVICENAME} -n ${NSE_NS} --kubeconfig ${KCONF2}
+kubectl get pods -n ${NSE_NS} --kubeconfig ${KCONF2}
 #kubectl get pods -n nsm-system --kubeconfig ${KCONF2}
 
 echo "# **** Install helloworld on cluster 1"

--- a/pkg/universal-cnf/vppagent/backend.go
+++ b/pkg/universal-cnf/vppagent/backend.go
@@ -78,6 +78,7 @@ func (b *UniversalCNFVPPAgentBackend) ProcessClient(
 				Memif: &interfaces.MemifLink{
 					Master:         false, // The client is not the master in MEMIF
 					SocketFilename: socketFilename,
+					RingSize:       512,
 				},
 			},
 		})
@@ -111,7 +112,12 @@ func (b *UniversalCNFVPPAgentBackend) ProcessEndpoint(
 	if len(dstIP) > net.IPv4len {
 		ipAddresses = append(ipAddresses, dstIP)
 	}
-
+	rxModes := []*interfaces.Interface_RxMode{
+		&interfaces.Interface_RxMode{
+			Mode:        interfaces.Interface_RxMode_INTERRUPT,
+			DefaultMode: true,
+		},
+	}
 	vppconfig.Interfaces = append(vppconfig.Interfaces,
 		&interfaces.Interface{
 			Name:        ifName + b.GetEndpointIfID(serviceName),
@@ -122,8 +128,10 @@ func (b *UniversalCNFVPPAgentBackend) ProcessEndpoint(
 				Memif: &interfaces.MemifLink{
 					Master:         true, // The endpoint is always the master in MEMIF
 					SocketFilename: socketFilename,
+					RingSize:       512,
 				},
 			},
+			RxModes: rxModes,
 		})
 
 	if err := os.MkdirAll(path.Dir(socketFilename), os.ModePerm); err != nil {

--- a/scripts/vl3/nsm_install_interdomain.sh
+++ b/scripts/vl3/nsm_install_interdomain.sh
@@ -62,7 +62,7 @@ helm template ${NSMDIR}/deployments/helm/skydive --namespace nsm-system --set in
 #kinddnsip=$(kubectl get svc ${KCONF:+--kubeconfig $KCONF} | grep kind-dns | awk '{ print $3 }')
 
 echo "------------Installing NSM-----------"
-helm template ${NSMDIR}/deployments/helm/nsm --namespace nsm-system --set org=${NSM_HUB},tag=${NSM_TAG} --set pullPolicy=Always --set insecure="true" --set global.JaegerTracing="true" ${SPIRE_DISABLED:+--set spire.enabled=false} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
+helm template ${NSMDIR}/deployments/helm/nsm --namespace nsm-system --set org=${NSM_HUB},tag=${NSM_TAG} --set admission-webhook.org=${NSM_HUB},admission-webhook.tag=${NSM_TAG} --set pullPolicy=Always --set insecure="true" --set global.JaegerTracing="true" ${SPIRE_DISABLED:+--set spire.enabled=false} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 echo "------------Installing NSM-addons -----------"
 helm template ${VL3DIR}/deployments/helm/nsm-addons --namespace nsm-system --set global.NSRegistrySvc=true  | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -

--- a/scripts/vl3/vl3_interdomain.sh
+++ b/scripts/vl3/vl3_interdomain.sh
@@ -103,7 +103,7 @@ fi
 
 echo "---------------Install NSE-------------"
 # ${KUBEINSTALL} -f ${VL3_NSEMFST}
-helm template ${VL3HELMDIR}/vl3 --set org=${NSE_HUB} --set tag=${NSE_TAG} --set pullPolicy=${PULLPOLICY} --set nsm.serviceName=${SERVICENAME} ${IPAMPOOL:+ --set nseControl.ipam.defaultPrefixPool=${IPAMPOOL}} --set nseControl.nsr.addr=${WCM_NSRADDR} ${WCM_NSRPORT:+ --set nseControl.nsr.port=${WCM_NSRPORT}} --namespace=${NAMESPACE} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
+helm template ${VL3HELMDIR}/vl3 --set org=${NSE_HUB} --set tag=${NSE_TAG} --set pullPolicy=${PULLPOLICY} --set nsm.serviceName=${SERVICENAME} ${IPAMPOOL:+ --set nseControl.ipam.defaultPrefixPool=${IPAMPOOL}} --set nseControl.nsr.addr=${WCM_NSRADDR} ${WCM_NSRPORT:+ --set nseControl.nsr.port=${WCM_NSRPORT}} --set replicaCount=2 --namespace=${NAMESPACE} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 if [[ "$INSTALL_OP" != "delete" ]]; then
   sleep 20


### PR DESCRIPTION
Changes tested with scale of clients for Vitess demo:
- memif interrupt mode instead of default polling mode
- reduce ring size to 512 from default of 1024
- increase vL3 NSE replica count to 2 in vl3_interdomain setup script
- also, pin the version of the nsm-init-container to the version built with the NSM version (admission-controller setting)

