### PR TITLE
Add optional NAT support for the Kiknos NS

### DIFF
--- a/build/nse/ucnf-kiknos/Makefile
+++ b/build/nse/ucnf-kiknos/Makefile
@@ -1,5 +1,5 @@
 # Parent image for the NSE
-VPP_AGENT = ciscolabs/kiknos:latest
+VPP_AGENT = ciscolabs/kiknos-sswan:latest
 
 # Set the cluster name
 CLUSTER ?= kiknos-demo-1

--- a/build/nse/ucnf-kiknos/README.md
+++ b/build/nse/ucnf-kiknos/README.md
@@ -94,12 +94,12 @@ Makefile consists of the following rules:
 Makefile options:
 
 - `CLUSTER` - Set the cluster name - (Default: `kiknos-demo-1`)
-- `ORG` - Set the org of new built image - (Default: `tiswanso`)
+- `ORG` - Set the org of new built image - (Default: `cisco-app-networking`)
 - `TAG` - Set the tag of new built image - (Default: `kiknos`)
 - `AWS_KEY_PAIR` - AWS Key Pair for connecting over SSH - (Default: `kiknos-asa`)
 - `CLUSTER_REF` - Reference cluster required when deploying the second cluster in
     order to be able to take some configurations such as remote IP address when configuring kiknos NSE or the AWS VPC - (Default: *None*)
-- `VPP_AGENT` - Parent image for the NSE - (Default: `ciscolabs/kiknos:latest`)
+- `VPP_AGENT` - Parent image for the NSE - (Default: `ciscolabs/kiknos-sswan:latest`)
 - `FORWARDING_PLANE` - Set a default forwarding plane - (Default: `vpp`)
 - `NETWORK_SERVICE` - Set a default network service for Example clients - (Default: `hello-world`)
 - `BUILD_IMAGE` - Set whether to build the image or not - (Default: `true`)

--- a/deployments/helm/ucnf-kiknos/istio_ingress/templates/istio-ingress.yaml
+++ b/deployments/helm/ucnf-kiknos/istio_ingress/templates/istio-ingress.yaml
@@ -35,7 +35,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
   annotations:
-    ns.networkservicemesh.io: {{ .Values.nsm.serviceName }}
+    ns.networkservicemesh.io: {{ .Values.nsm.serviceName }}?nat-port-forward-tcp=80
 spec:
   selector:
     matchLabels:

--- a/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/README.md
+++ b/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/README.md
@@ -1,0 +1,84 @@
+# Kiknos VPN Endpoint NSE
+This folder contains a Helm chart for the Kiknos VPN Endpoint NSE. This document describes the most
+important parts that may be needed in order to tweak the NSE deployment.
+
+
+## Important Helm options
+The default values for Helm options present in [values.yaml](values.yaml) file can be generally preserved,
+except the following options that usually have to be tweaked for each deployment:
+
+| Helm Option                          | Example Value                      | Description |
+| ------------------------------------ | ---------------------------------- | ----------- |
+| `strongswan.network.localSubnet`     | `172.31.23.0/24`                   | Local IP subnet exposed via the IPSec tunnel to the remote peers. It can be a /32 NAT subnet (e.g. `1.2.3.4/32`) in case that NAT is enabled. |
+| `strongswan.network.remoteSubnets`   | `{172.31.23.0/24,172.31.100.0/24}` | Array of remote IP subnets accessible via IPSec tunnels. This usually matches to an array of the local subnets of individual remote IPSec peers. |
+| `strongswan.network.remoteAddr`      | `81.82.123.124`                    | (optional) IP address of the remote IPSec peer. Required only if this NSE acts as an IPSec client initiating a connection to the remote gateway/peer. Leave empty if this NSE acts as an IPSec gateway. |
+| `strongswan.secrets.ikePreSharedKey` | `Vpp123`                           | Pre-shared-key used to authenticate with remote IPSec peers. |
+| `nse.localSubnet`                    | `172.31.23.0/24`                   | Local NSE's IPAM prefix pool (subnet used to address the NSM links between the gateway and NSM-enabled pods). If NAT is *not* enabled, this is equal to `strongswan.network.localSubnet` |
+| `nse.natIP`                          | `1.2.3.4`                          | (optional) If set, this enables source NAT on the IPSec interfaces. All traffic going from the cluster to the remote peers will be NATed to this IP. If enabled, `strongswan.network.localSubnet` needs to be set to `<this-IP>/32`. |
+
+
+## StrongSwan configuration files
+There are two StrongSwan configuration files embedded in this helm chart. Most often they don't have to be
+touched, since they are parametrized using the aforementioned helm options, but the parts that are not exposed
+via the helm options can still be tweaked if needed:
+
+- [strongswan-cfg.yaml](templates/strongswan-cfg.yaml): contains generic StrongSwan configuration,
+ such as the count of StrongSwan threads or timeout values,
+- [responder-cfg.yaml](templates/responder-cfg.yaml): contains IPSec connection configuration,
+ such as authentication and encryption algorithms.
+
+
+## VPP startup configuration file
+VPP startup configuration generally does not require any tweaks, but it is located in
+[vpp-cfg.yaml](templates/vpp-cfg.yaml) file in case that any changes are required.
+
+
+## NAT-enabled deployment
+Source NAT on IPSec tunnel interfaces can be enabled with the helm option `nse.natIP`. Its value should contain
+the requested outside NAT IP address, e.g. `nse.natIP=1.2.3.4`.
+
+Enabling NAT results into the following configuration on the NSE VPP:
+
+- each NSC-facing interface is configured as "NAT inside"
+- each IPSec (IPIP) tunnel interface is configured as "NAT outside"
+
+```
+vpp# sh nat44 interfaces
+NAT44 interfaces:
+ memif1/0 in
+ memif2/0 in
+ memif3/0 in
+ ipip0 out
+```
+
+NAT pool is configured to the NAT IP provided in the `nse.natIP` helm option:
+
+```
+vpp# sh nat44 addresses
+NAT44 pool addresses:
+1.2.3.4
+  tenant VRF: 0
+  0 busy other ports
+  0 busy udp ports
+  0 busy tcp ports
+  0 busy icmp ports
+```
+
+At this point, every connection from inside (NSCs) to outside (remote IPSec peers) is source-NATed to the
+configured NAT IP. Connections from outside to inside are not allowed (not to NAT IP nor NSC IPs).
+To allow outside-to-inside connections, NSC has to request forwarding of a specific TCP/UDP port to them.
+They can do it with lables in `networkservicemesh.io` annotations, e.g.
+`ns.networkservicemesh.io: nsm-service-name?nat-port-forward-tcp=80` to forward TCP port 80, or
+`ns.networkservicemesh.io: nsm-service-name?nat-port-forward-udp=53` to port forward UDP port 53.
+
+That renders into a static nat44 mapping configuration on VPP, e.g.:
+
+```
+vpp# sh nat44 static mappings
+NAT44 static mappings:
+ tcp local 172.31.22.9:80 external 1.2.3.4:80 vrf 0  out2in-only
+```
+
+In our setup, the Istio NSC requests port forwarding on port 80 with
+`ns.networkservicemesh.io: {{ .Values.nsm.serviceName }}?nat-port-forward-tcp=80`,
+which means that remote IPSec peers can access the Istio ingress gateway running in the cluster at `http://1.2.3.4:80`.

--- a/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/templates/kiknos-nse-ucnf.yaml
+++ b/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/templates/kiknos-nse-ucnf.yaml
@@ -60,6 +60,10 @@ spec:
                   fieldPath: status.podIP
             - name: MICROSERVICE_LABEL
               value: {{ .Values.aio.serviceLabel }}
+            {{- if .Values.nse.natIP }}
+            - name: NSE_NAT_IP
+              value: "{{ .Values.nse.natIP }}"
+            {{- end }}
           securityContext:
             capabilities:
               add:
@@ -194,7 +198,7 @@ data:
         app: "vl3-nse-{{ .Values.nsm.serviceName }}"
       vl3:
         ipam:
-          defaultPrefixPool: {{ .Values.strongswan.network.localSubnet | quote }}
+          defaultPrefixPool: {{ .Values.nse.localSubnet | quote }}
           routes: {{ .Values.strongswan.network.remoteSubnets | toJson }}
         ifName: "endpoint0"
 
@@ -253,18 +257,21 @@ data:
     client-basic-auth:
       - {{ .Values.aio.http.secrets.basicAuth | quote }}
     {{- end }}
-  {{- if .Values.strongswan.secrets.encryption.enabled }}
-  kiknos.conf: |
-    KiknosConfig:
+  kiknoscfg.conf: |
+    kiknosConfig:
+      {{- if .Values.nse.natIP }}
+      natOutside: true
+      {{- end }}
+      {{- if .Values.strongswan.secrets.encryption.enabled }}
       secretsKeyFile: /var/strongswan/secrets/{{ .Values.strongswan.secrets.encryption.privateKeyFile }}
-  {{- end }}
+      {{- end }}
   supervisor.conf: |
     programs:
       - name: "vpp"
         executable-path: "/usr/bin/vpp"
         executable-args: ["-c", "/etc/vpp/vpp.conf"]
       - name: "aio-agent"
-        executable-path: "{{if.Values.development.useDevImages}}/go/bin/{{else}}/usr/bin/{{end}}aio-agent"
+        executable-path: "{{if.Values.development.useDevImages}}/go/bin/{{else}}/usr/bin/{{end}}aio-sswan-agent"
         executable-args: ["--config-dir=/opt/aio-agent/dev"]
       - name: "strongswan"
         executable-path: "/usr/local/libexec/ipsec/charon"

--- a/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/templates/vpp-cfg.yaml
+++ b/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/templates/vpp-cfg.yaml
@@ -25,3 +25,6 @@ data:
         disable
       }
     }
+    nat {
+      endpoint-dependent
+    }

--- a/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/values.yaml
+++ b/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/values.yaml
@@ -20,6 +20,10 @@ ipam:
   prefixPool: "172.31.0.0/16"
   # uniqueOctet:
 
+nse:
+  localSubnet: 172.31.22.0/24
+  # natIP:
+
 global:
 
 replicaCount: 1

--- a/pkg/universal-cnf/vppagent/backend.go
+++ b/pkg/universal-cnf/vppagent/backend.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/memif"
@@ -28,6 +29,7 @@ import (
 	"go.ligato.io/vpp-agent/v3/proto/ligato/vpp"
 	interfaces "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/interfaces"
 	vpp_l3 "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/l3"
+	vpp_nat "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/nat"
 )
 
 // UniversalCNFVPPAgentBackend is the VPP CNF backend struct
@@ -112,9 +114,10 @@ func (b *UniversalCNFVPPAgentBackend) ProcessEndpoint(
 		ipAddresses = append(ipAddresses, dstIP)
 	}
 
+	endpointIfName := ifName + b.GetEndpointIfID(serviceName)
 	vppconfig.Interfaces = append(vppconfig.Interfaces,
 		&interfaces.Interface{
-			Name:        ifName + b.GetEndpointIfID(serviceName),
+			Name:        endpointIfName,
 			Type:        interfaces.Interface_MEMIF,
 			Enabled:     true,
 			IpAddresses: ipAddresses,
@@ -138,6 +141,52 @@ func (b *UniversalCNFVPPAgentBackend) ProcessEndpoint(
 			NextHopAddr: srcIP.String(),
 		}
 		vppconfig.Routes = append(vppconfig.Routes, route)
+	}
+
+	// NAT configuration
+	if natIP := os.Getenv("NSE_NAT_IP"); natIP != "" {
+		// configure NAT pool - TODO: move pool config to some global init place?
+		natPool := &vpp_nat.Nat44AddressPool{FirstIp: natIP}
+		vppconfig.Nat44Pools = append(vppconfig.Nat44Pools, natPool)
+
+		// enable NAT on the interface
+		natIf := &vpp_nat.Nat44Interface{
+			Name:      endpointIfName,
+			NatInside: true,
+		}
+		vppconfig.Nat44Interfaces = append(vppconfig.Nat44Interfaces, natIf)
+
+		// add static NAT mappings for port forward requests
+		for k, v := range conn.Labels {
+			if strings.HasPrefix(k, "nat-port-forward") {
+				port, err := strconv.Atoi(v)
+				if err != nil {
+					logrus.Errorf("cannot convert port number %s: %v", v, err)
+					continue
+				}
+				natMapping := &vpp_nat.DNat44{
+					Label: k + "-to-" + srcIP.String(),
+					StMappings: []*vpp_nat.DNat44_StaticMapping{
+						{
+							ExternalIp:   natIP,
+							ExternalPort: uint32(port),
+							LocalIps: []*vpp_nat.DNat44_StaticMapping_LocalIP{
+								{
+									LocalIp:   srcIP.String(),
+									LocalPort: uint32(port),
+								},
+							},
+						},
+					},
+				}
+				if strings.Contains(k, "udp") {
+					natMapping.StMappings[0].Protocol = vpp_nat.DNat44_UDP
+				} else {
+					natMapping.StMappings[0].Protocol = vpp_nat.DNat44_TCP
+				}
+				vppconfig.Dnat44S = append(vppconfig.Dnat44S, natMapping)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/universal-cnf/vppagent/backend.go
+++ b/pkg/universal-cnf/vppagent/backend.go
@@ -154,9 +154,11 @@ func (b *UniversalCNFVPPAgentBackend) ProcessEndpoint(
 
 	// NAT configuration
 	if natIP := os.Getenv("NSE_NAT_IP"); natIP != "" {
-		// configure NAT pool - TODO: move pool config to some global init place?
-		natPool := &vpp_nat.Nat44AddressPool{FirstIp: natIP}
-		vppconfig.Nat44Pools = append(vppconfig.Nat44Pools, natPool)
+		// configure NAT pool (only once) - TODO: move pool config to some global init place?
+		if b.EndpointIfID[serviceName] == 0 {
+			natPool := &vpp_nat.Nat44AddressPool{FirstIp: natIP}
+			vppconfig.Nat44Pools = append(vppconfig.Nat44Pools, natPool)
+		}
 
 		// enable NAT on the interface
 		natIf := &vpp_nat.Nat44Interface{

--- a/scripts/asa/day0-config
+++ b/scripts/asa/day0-config
@@ -25,7 +25,7 @@ ssh 192.168.1.0 255.255.255.0 management
 ssh version 2
 ssh key-exchange group dh-group14-sha1
 aaa authentication ssh console LOCAL
-access-list ikev2-list extended permit ip 172.31.100.0 255.255.255.0 172.31.22.0 255.255.255.0
+access-list ikev2-list extended permit ip 172.31.100.0 255.255.255.0 1.2.3.4 255.255.255.255
 route outside 172.17.0.0 255.255.0.0 198.51.100.10 1
 crypto ipsec ikev2 ipsec-proposal ikev2-proposal
  protocol esp encryption aes

--- a/scripts/ucnf-kiknos/day0.txt
+++ b/scripts/ucnf-kiknos/day0.txt
@@ -27,7 +27,7 @@ username admin nopassword privilege 15
 username admin attributes
 service-type admin
 !
-access-list ikev2-list extended permit ip <HOST_NETWORK> 255.255.255.0 172.31.22.0 255.255.255.0
+access-list ikev2-list extended permit ip <HOST_NETWORK> 255.255.255.0 1.2.3.4 255.255.255.255
 crypto ipsec ikev2 ipsec-proposal ikev2-proposal                                                                                                                                                              
  protocol esp encryption aes                                                                                                                                                                                  
  protocol esp integrity sha-1                                                                                                                                                                                 


### PR DESCRIPTION
Add optional NAT support for the Kiknos NSE. It is disabled by default and can be enabled by:

- `nse.natIP` Helm option
- `NSE_NAT_IP` env var in the deployment scripts, e.g. `make deploy-kiknos-clients CLUSTER=kiknos-demo-1 NSE_NAT_IP=1.2.3.4`

More info in the included README.