### PR TITLE
UCNF: add DNS zones and nameservers to config and add DNScontext

### DIFF
--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -105,6 +105,12 @@ data:
           prefixLength: {{ .Values.nseControl.ipam.prefixLength }}
           routes: []
        ifName: "endpoint0"
+{{- if .Values.nseControl.nameserver }}
+       nameServers:
+          - {{ .Values.nseControl.nameserver }}
+       dnsZones:
+          - {{ .Values.nseControl.dnszone }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/deployments/helm/vl3/values.yaml
+++ b/deployments/helm/vl3/values.yaml
@@ -14,7 +14,8 @@ nseControl:
     port: 5005
     addr: vl3-service.wcm-cisco.com
     cd: vl3-service-connectivity-domain
-#  domain: nsr.foo.com
+# nameserver: 1.2.3.4
+# dnszone: cappnet-example.com
   ipam:
     defaultPrefixPool: 192.168.0.0/16
     prefixLength: 22

--- a/pkg/nseconfig/config.go
+++ b/pkg/nseconfig/config.go
@@ -34,6 +34,7 @@ type VL3 struct {
 	IPAM        IPAM     `yaml:"ipam"`
 	Ifname      string   `yaml:"ifName"`
 	NameServers []string `yaml:"nameServers"`
+	DNSZones    []string `yaml:"dnsZones"`
 }
 
 type IPAM struct {

--- a/pkg/universal-cnf/config/composite.go
+++ b/pkg/universal-cnf/config/composite.go
@@ -98,3 +98,23 @@ func makeRouteMutator(routes []string) endpoint.ConnectionMutator {
 		return nil
 	}
 }
+
+func makeDnsMutator(dnsZones, nameservers []string) endpoint.ConnectionMutator {
+	return func(ctx context.Context, c *connection.Connection) error {
+		logrus.Infof("Universal CNF DNS composite endpoint: %v", c)
+		dnsConfig := &connectioncontext.DNSConfig{}
+		for _, zone := range dnsZones {
+			 dnsConfig.SearchDomains = append(dnsConfig.SearchDomains, zone)
+		}
+		for _, server := range nameservers {
+			dnsConfig.DnsServerIps = append(dnsConfig.DnsServerIps, server)
+		}
+		logrus.Infof("Universal CNF DNS composite endpoint adding DNSConfig: %v", dnsConfig)
+		if c.GetContext().GetDnsContext() == nil {
+			c.GetContext().DnsContext = &connectioncontext.DNSContext{}
+		}
+		c.GetContext().DnsContext.Configs = append(c.GetContext().DnsContext.Configs,
+			dnsConfig)
+		return nil
+	}
+}

--- a/pkg/universal-cnf/config/composite.go
+++ b/pkg/universal-cnf/config/composite.go
@@ -104,7 +104,7 @@ func makeDnsMutator(dnsZones, nameservers []string) endpoint.ConnectionMutator {
 		logrus.Infof("Universal CNF DNS composite endpoint: %v", c)
 		dnsConfig := &connectioncontext.DNSConfig{}
 		for _, zone := range dnsZones {
-			 dnsConfig.SearchDomains = append(dnsConfig.SearchDomains, zone)
+			dnsConfig.SearchDomains = append(dnsConfig.SearchDomains, zone)
 		}
 		for _, server := range nameservers {
 			dnsConfig.DnsServerIps = append(dnsConfig.DnsServerIps, server)

--- a/pkg/universal-cnf/config/config_endpoints.go
+++ b/pkg/universal-cnf/config/config_endpoints.go
@@ -105,6 +105,10 @@ func NewProcessEndpoints(backend UniversalCNFBackend, endpoints []*nseconfig.End
 			routeAddr := makeRouteMutator(e.VL3.IPAM.Routes)
 			compositeEndpoints = append(compositeEndpoints, endpoint.NewCustomFuncEndpoint("route", routeAddr))
 		}
+		if len(e.VL3.NameServers) > 0 {
+			dnsServers := makeDnsMutator(e.VL3.DNSZones, e.VL3.NameServers)
+			compositeEndpoints = append(compositeEndpoints, endpoint.NewCustomFuncEndpoint("dns", dnsServers))
+		}
 
 		compositeEndpoints = append(compositeEndpoints, NewUniversalCNFEndpoint(backend, e))
 		// Compose the Endpoint

--- a/scripts/vl3/vl3_interdomain.sh
+++ b/scripts/vl3/vl3_interdomain.sh
@@ -13,7 +13,7 @@ Options:
 
 NSE_HUB=${NSE_HUB:-"ciscoappnetworking"}
 NSE_TAG=${NSE_TAG:-"kind_ci"}
-PULLPOLICY=${PULLPOLICY:-IfNotPresent}
+PULLPOLICY=${PULLPOLICY:-Always}
 INSTALL_OP=${INSTALL_OP:-apply}
 SERVICENAME=${SERVICENAME:-vl3-service}
 NAMESPACE=${NAMESPACE:-"wcm-system"}
@@ -47,6 +47,12 @@ for i in "$@"; do
             ;;
         --wcmNsrPort=?*)
             WCM_NSRPORT=${i#*=}
+            ;;
+        --nameserver=?*)
+            NAMESERVER=${i#*=}
+            ;;
+        --dnszone=?*)
+            DNSZONE=${i#*=}
             ;;
         --cleanup|--delete)
             INSTALL_OP=delete
@@ -103,7 +109,7 @@ fi
 
 echo "---------------Install NSE-------------"
 # ${KUBEINSTALL} -f ${VL3_NSEMFST}
-helm template ${VL3HELMDIR}/vl3 --set org=${NSE_HUB} --set tag=${NSE_TAG} --set pullPolicy=${PULLPOLICY} --set nsm.serviceName=${SERVICENAME} ${IPAMPOOL:+ --set nseControl.ipam.defaultPrefixPool=${IPAMPOOL}} --set nseControl.nsr.addr=${WCM_NSRADDR} ${WCM_NSRPORT:+ --set nseControl.nsr.port=${WCM_NSRPORT}} --set replicaCount=2 --namespace=${NAMESPACE} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
+helm template ${VL3HELMDIR}/vl3 --set org=${NSE_HUB} --set tag=${NSE_TAG} --set pullPolicy=${PULLPOLICY} --set nsm.serviceName=${SERVICENAME} ${IPAMPOOL:+ --set nseControl.ipam.defaultPrefixPool=${IPAMPOOL}} --set nseControl.nsr.addr=${WCM_NSRADDR} ${WCM_NSRPORT:+ --set nseControl.nsr.port=${WCM_NSRPORT}} --set replicaCount=2 --namespace=${NAMESPACE} ${NAMESERVER:+ --set nseControl.nameserver=${NAMESERVER}} ${DNSZONE:+ --set nseControl.dnszone=${DNSZONE}} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 if [[ "$INSTALL_OP" != "delete" ]]; then
   sleep 20

--- a/scripts/vl3/vl3_interdomain.sh
+++ b/scripts/vl3/vl3_interdomain.sh
@@ -13,7 +13,7 @@ Options:
 
 NSE_HUB=${NSE_HUB:-"ciscoappnetworking"}
 NSE_TAG=${NSE_TAG:-"kind_ci"}
-PULLPOLICY=${PULLPOLICY:-Always}
+PULLPOLICY=${PULLPOLICY:-IfNotPresent}
 INSTALL_OP=${INSTALL_OP:-apply}
 SERVICENAME=${SERVICENAME:-vl3-service}
 NAMESPACE=${NAMESPACE:-"wcm-system"}


### PR DESCRIPTION
- add composite endpoint for DNScontext if nameserver NSE config is set
- the NSC injected sidecars will setup private DNS access for the pod:  
   - nsm-dns-monitor will configure the coredns sidecar based on the DNScontext

