### PR TITLE
vL3 fixes to restore functionality without presence of IPAM or service mapping servers--fixes CI

### DIFF
--- a/build/ci/runner/run_vl3.sh
+++ b/build/ci/runner/run_vl3.sh
@@ -77,11 +77,11 @@ echo "# **** Install helloworld on cluster 2"
 helm template deployments/helm/vl3_hello --set nsm.serviceName=${SERVICENAME} --set replicaCount=1 | kubectl apply --kubeconfig ${KCONF2} -f -
 
 echo "# **** wait on helloworld pods to come up"
-kubectl wait --kubeconfig ${KCONF1} --timeout=600s --for condition=Ready -l app=helloworld pod
-kubectl wait --kubeconfig ${KCONF2} --timeout=600s --for condition=Ready -l app=helloworld pod
+kubectl wait --kubeconfig ${KCONF1} --timeout=600s --for condition=Ready -l app=helloworld-${SERVICENAME} pod
+kubectl wait --kubeconfig ${KCONF2} --timeout=600s --for condition=Ready -l app=helloworld-${SERVICENAME} pod
 
-K1_PODNM=$(kubectl get pods --kubeconfig ${KCONF1} -l "app=helloworld" -o jsonpath="{.items[0].metadata.name}")
-K2_PODNM=$(kubectl get pods --kubeconfig ${KCONF2} -l "app=helloworld" -o jsonpath="{.items[0].metadata.name}")
+K1_PODNM=$(kubectl get pods --kubeconfig ${KCONF1} -l "app=helloworld-${SERVICENAME}" -o jsonpath="{.items[0].metadata.name}")
+K2_PODNM=$(kubectl get pods --kubeconfig ${KCONF2} -l "app=helloworld-${SERVICENAME}" -o jsonpath="{.items[0].metadata.name}")
 
 K1_PODIP=$(kubectl exec -t $K1_PODNM -c helloworld --kubeconfig ${KCONF1} -- ip a show dev nsm0 | awk '$1 == "inet" {gsub(/\/.*$/, "", $2); print $2}')
 

--- a/build/ci/runner/run_vl3.sh
+++ b/build/ci/runner/run_vl3.sh
@@ -71,7 +71,7 @@ kubectl get pods -n ${NSE_NS} --kubeconfig ${KCONF2}
 echo "# **** Install helloworld on cluster 1"
 helm template deployments/helm/vl3_hello --set nsm.serviceName=${SERVICENAME} --set replicaCount=1 | kubectl apply --kubeconfig ${KCONF1} -f -
 
-sleep 60
+sleep 5
 
 echo "# **** Install helloworld on cluster 2"
 helm template deployments/helm/vl3_hello --set nsm.serviceName=${SERVICENAME} --set replicaCount=1 | kubectl apply --kubeconfig ${KCONF2} -f -

--- a/build/nse/vl3-nse/README.md
+++ b/build/nse/vl3-nse/README.md
@@ -24,18 +24,22 @@ This is an NSE that creates a L3 routing domain between NSC workloads. Each NSE 
       1. respond
       1. setup VPP agent for the peer connection
 
-## Single NSM Domain
-
-### Constraints
+## Prereqs
 
 1. This currently only works with a custom version of the NSM installation.
 
     ```sh
     mkdir -p $GOPATH/src/github.com/cisco-app-networking
+    git clone https://github.com/cisco-app-networking/networkservicemesh
+    cd networkservicemesh
+    git checkout vl3_latest
+    cd ..
     git clone https://github.com/cisco-app-networking/nsm-nse
     ```
    
 2. The `demo_*.sh` scripts in this repo work with `demo-magic` which has a dependency on `pv` (ie. `brew install pv`)
+
+## Single NSM Domain
 
 ### Usage
 

--- a/cmd/vl3-nse/nse.go
+++ b/cmd/vl3-nse/nse.go
@@ -69,9 +69,6 @@ func (e vL3CompositeEndpoint) AddCompositeEndpoints(nsConfig *common.NSConfigura
 		"prefixPool":         nsConfig.IPAddress,
 		"nsConfig.IPAddress": nsConfig.IPAddress,
 	}).Infof("Creating vL3 IPAM endpoint")
-	//ipamEp := endpoint.NewIpamEndpoint(&common.NSConfiguration{
-	//	IPAddress: nsConfig.IPAddress,
-	//})
 
 	var nsRemoteIpList []string
 	nsRemoteIpListStr, ok := os.LookupEnv("NSM_REMOTE_NS_IP_LIST")
@@ -79,7 +76,6 @@ func (e vL3CompositeEndpoint) AddCompositeEndpoints(nsConfig *common.NSConfigura
 		nsRemoteIpList = strings.Split(nsRemoteIpListStr, ",")
 	}
 	compositeEndpoints := []networkservice.NetworkServiceServer{
-		//ipamEp,
 		newVL3ConnectComposite(nsConfig, nsConfig.IPAddress,
 			&vppagent.UniversalCNFVPPAgentBackend{}, nsRemoteIpList, func() string {
 				return ucnfEndpoint.NseName

--- a/cmd/vl3-nse/nse.go
+++ b/cmd/vl3-nse/nse.go
@@ -25,7 +25,6 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/networkservicemesh/networkservicemesh/sdk/common"
-	"github.com/networkservicemesh/networkservicemesh/sdk/endpoint"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
@@ -70,9 +69,9 @@ func (e vL3CompositeEndpoint) AddCompositeEndpoints(nsConfig *common.NSConfigura
 		"prefixPool":         nsConfig.IPAddress,
 		"nsConfig.IPAddress": nsConfig.IPAddress,
 	}).Infof("Creating vL3 IPAM endpoint")
-	ipamEp := endpoint.NewIpamEndpoint(&common.NSConfiguration{
-		IPAddress: nsConfig.IPAddress,
-	})
+	//ipamEp := endpoint.NewIpamEndpoint(&common.NSConfiguration{
+	//	IPAddress: nsConfig.IPAddress,
+	//})
 
 	var nsRemoteIpList []string
 	nsRemoteIpListStr, ok := os.LookupEnv("NSM_REMOTE_NS_IP_LIST")
@@ -80,7 +79,7 @@ func (e vL3CompositeEndpoint) AddCompositeEndpoints(nsConfig *common.NSConfigura
 		nsRemoteIpList = strings.Split(nsRemoteIpListStr, ",")
 	}
 	compositeEndpoints := []networkservice.NetworkServiceServer{
-		ipamEp,
+		//ipamEp,
 		newVL3ConnectComposite(nsConfig, nsConfig.IPAddress,
 			&vppagent.UniversalCNFVPPAgentBackend{}, nsRemoteIpList, func() string {
 				return ucnfEndpoint.NseName

--- a/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/values.yaml
+++ b/deployments/helm/ucnf-kiknos/kiknos_vpn_endpoint/values.yaml
@@ -1,8 +1,8 @@
 ---
 
 registry: docker.io
-org: networkservicemesh
-tag: latest
+org: ciscoappnetworking
+tag: master
 pullPolicy: IfNotPresent
 
 nseControl:

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -51,6 +51,10 @@ spec:
               value: "nsmgr.nsm-system"
             - name: NSREGISTRY_PORT
               value: "5000"
+{{- if .Values.ipamUniqueOctet }}
+            - name: NSE_IPAM_UNIQUE_OCTET
+              value: {{ .Values.ipamUniqueOctet | quote }}
+{{- end }}
             - name: NSE_POD_IP
               valueFrom:
                 fieldRef:
@@ -101,7 +105,9 @@ data:
       vl3:
        ipam:
           defaultPrefixPool: {{ .Values.nseControl.ipam.defaultPrefixPool | quote }}
+{{- if .Values.nseControl.nsr.addr }}
           serverAddress: "ipam-{{ .Values.nseControl.nsr.addr }}:50051"
+{{- end }}
           prefixLength: {{ .Values.nseControl.ipam.prefixLength }}
           routes: []
        ifName: "endpoint0"

--- a/deployments/helm/vl3/values.yaml
+++ b/deployments/helm/vl3/values.yaml
@@ -3,9 +3,9 @@
 # Declare variables to be passed into your templates.
 
 registry: docker.io
-org: tiswanso
-tag: unified_api_ipam
-pullPolicy: Always
+org: ciscoappnetworking
+tag: master
+pullPolicy: IfNotPresent
 vppMetricsPort: 9191
 metricsPort: 2112
 

--- a/pkg/universal-cnf/ucnf/ucnf_nse.go
+++ b/pkg/universal-cnf/ucnf/ucnf_nse.go
@@ -38,7 +38,7 @@ func NewUcnfNse(configPath string, verify bool, backend config.UniversalCNFBacke
 
 	err = nseconfig.NewConfig(yaml.NewDecoder(f), cnfConfig)
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.Warningf("NSE config errors: %v", err)
 	}
 
 	if err := backend.NewUniversalCNFBackend(); err != nil {

--- a/scripts/vl3/demo_vl3.sh
+++ b/scripts/vl3/demo_vl3.sh
@@ -138,11 +138,11 @@ fi
 p "# --------------------- Virtual L3 Setup ------------------------"
 
 pe "# **** Install vL3 in cluster 1"
-pc "${DELETE:+INSTALL_OP=delete} REMOTE_IP=${clus2_IP} KCONF=${KCONF_CLUS1} PULLPOLICY=Always scripts/vl3/vl3_interdomain.sh --ipamOctet=22 ${WCM_NSRADDR:+--wcmNsrAddr=${WCM_NSRADDR}} ${WCM_NSRPORT:+--wcmNsrPort=${WCM_NSRPORT}}"
+pc "${DELETE:+INSTALL_OP=delete} REMOTE_IP=${clus2_IP} KCONF=${KCONF_CLUS1} PULLPOLICY=Always NSEREPLICAS=1 scripts/vl3/vl3_interdomain.sh --ipamOctet=22 ${WCM_NSRADDR:+--wcmNsrAddr=${WCM_NSRADDR}} ${WCM_NSRPORT:+--wcmNsrPort=${WCM_NSRPORT}}"
 pc "kubectl get pods --kubeconfig ${KCONF_CLUS1} -o wide"
 echo
 pe "# **** Install vL3  in cluster 2"
-pc "${DELETE:+INSTALL_OP=delete} REMOTE_IP=${clus1_IP} KCONF=${KCONF_CLUS2} PULLPOLICY=Always scripts/vl3/vl3_interdomain.sh --ipamOctet=33 ${WCM_NSRADDR:+--wcmNsrAddr=${WCM_NSRADDR}} ${WCM_NSRPORT:+--wcmNsrPort=${WCM_NSRPORT}}"
+pc "${DELETE:+INSTALL_OP=delete} REMOTE_IP=${clus1_IP} KCONF=${KCONF_CLUS2} PULLPOLICY=Always NSEREPLICAS=1 scripts/vl3/vl3_interdomain.sh --ipamOctet=33 ${WCM_NSRADDR:+--wcmNsrAddr=${WCM_NSRADDR}} ${WCM_NSRPORT:+--wcmNsrPort=${WCM_NSRPORT}}"
 #pc "kubectl get pods --kubeconfig ${KCONF_CLUS2} -o wide"
 echo
 p "# **** Virtual L3 service definition (CRD) ***"

--- a/scripts/vl3/nsm_install_interdomain.sh
+++ b/scripts/vl3/nsm_install_interdomain.sh
@@ -13,8 +13,8 @@ Options:
 " >&2
 }
 
-NSM_HUB="${NSM_HUB:-"tiswanso"}"
-NSM_TAG="${NSM_TAG:-"vl3_api_rebase"}"
+NSM_HUB="${NSM_HUB:-"ciscoappnetworking"}"
+NSM_TAG="${NSM_TAG:-"vl3_latest"}"
 INSTALL_OP=${INSTALL_OP:-apply}
 
 for i in "$@"


### PR DESCRIPTION
- fix standalone NSM + vL3 demo for scenarios without implementations of IPAM or service mapping servers
- allow for config of unique IPAM octet or deriving unique octet from the NSE pod IP
- make helm default images use publish locations
- this PR is on top of the diffs for #18 

circleci job with this change:  https://app.circleci.com/pipelines/github/tiswanso/nsm-nse/20/workflows/1e986f79-0534-4b1c-a159-85f167b81685