### PR TITLE
vl3-nse: remove client facing interfaces

### DIFF
--- a/cmd/vl3-nse/vl3_connect.go
+++ b/cmd/vl3-nse/vl3_connect.go
@@ -350,7 +350,7 @@ func (vxc *vL3ConnectComposite) createPeerConnectionRequest(ctx context.Context,
 		return peer.connErr
 	}
 
-	if peer.connErr = vxc.backend.ProcessDPConfig(dpconfig); peer.connErr != nil {
+	if peer.connErr = vxc.backend.ProcessDPConfig(dpconfig, true); peer.connErr != nil {
 		logger.Errorf("endpoint %s Error processing dpconfig: %+v -- %v", peer.endpointName, dpconfig, peer.connErr)
 		peer.state = PEER_STATE_CONNERR
 		return peer.connErr

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -25,8 +25,8 @@ spec:
     spec:
       containers:
         - name: vl3-nse
-          image: {{ .Values.registry }}/{{ .Values.org }}/vl3_ucnf-nse:{{ .Values.tag }}
-          imagePullPolicy: {{ .Values.pullPolicy }}
+          image: cosminpetru/vl3_ucnf-nse:latest
+          imagePullPolicy: Always
           ports:
           - name: monitoring-vpp
             containerPort: {{ .Values.vppMetricsPort }}

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -25,8 +25,8 @@ spec:
     spec:
       containers:
         - name: vl3-nse
-          image: cosminpetru/vl3_ucnf-nse:latest
-          imagePullPolicy: Always
+          image: {{ .Values.registry }}/{{ .Values.org }}/vl3_ucnf-nse:{{ .Values.tag }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
           ports:
           - name: monitoring-vpp
             containerPort: {{ .Values.vppMetricsPort }}

--- a/pkg/universal-cnf/config/config.go
+++ b/pkg/universal-cnf/config/config.go
@@ -90,7 +90,7 @@ func (a *Action) Process(ctx context.Context, backend UniversalCNFBackend, nsmcl
 		}
 	}
 
-	if err := backend.ProcessDPConfig(a.DPConfig); err != nil {
+	if err := backend.ProcessDPConfig(a.DPConfig, true); err != nil {
 		logrus.Errorf("Error processing dpconfig: %+v", a.DPConfig)
 	}
 
@@ -123,7 +123,7 @@ type UniversalCNFBackend interface {
 	NewUniversalCNFBackend() error
 	ProcessClient(dpconfig interface{}, ifName string, conn *connection.Connection) error
 	ProcessEndpoint(dpconfig interface{}, serviceName, ifName string, conn *connection.Connection) error
-	ProcessDPConfig(dpconfig interface{}) error
+	ProcessDPConfig(dpconfig interface{}, createOrUpdate bool) error
 }
 
 // UniversalCNFConfig hold the CNF configuration

--- a/pkg/universal-cnf/config/config.go
+++ b/pkg/universal-cnf/config/config.go
@@ -123,7 +123,7 @@ type UniversalCNFBackend interface {
 	NewUniversalCNFBackend() error
 	ProcessClient(dpconfig interface{}, ifName string, conn *connection.Connection) error
 	ProcessEndpoint(dpconfig interface{}, serviceName, ifName string, conn *connection.Connection) error
-	ProcessDPConfig(dpconfig interface{}, createOrUpdate bool) error
+	ProcessDPConfig(dpconfig interface{}, update bool) error
 }
 
 // UniversalCNFConfig hold the CNF configuration

--- a/pkg/universal-cnf/vppagent/backend.go
+++ b/pkg/universal-cnf/vppagent/backend.go
@@ -122,6 +122,7 @@ func (b *UniversalCNFVPPAgentBackend) ProcessEndpoint(
 			DefaultMode: true,
 		},
 	}
+
 	vppconfig.Interfaces = append(vppconfig.Interfaces,
 		&interfaces.Interface{
 			Name:        endpointIfName,
@@ -215,13 +216,21 @@ func (b *UniversalCNFVPPAgentBackend) GetEndpointIfID(serviceName string) string
 }
 
 // ProcessDPConfig applies the VPP CNF configuration to VPP
-func (b *UniversalCNFVPPAgentBackend) ProcessDPConfig(dpconfig interface{}) error {
+func (b *UniversalCNFVPPAgentBackend) ProcessDPConfig(dpconfig interface{}, createOrUpdate bool) error {
 	vppconfig, ok := dpconfig.(*vpp.ConfigData)
 	if !ok {
 		return fmt.Errorf("unable to convert dpconfig to vppconfig	")
 	}
 
-	err := SendVppConfigToVppAgent(vppconfig, true)
+	if !createOrUpdate {
+		logrus.Println("[COSMIN] ProcessDPConfig. dpconfig: interfaces")
+		for _, inter := range vppconfig.Interfaces {
+			logrus.Println("[COSMIN] interface:", inter)
+		}
+	}
+
+	err := SendVppConfigToVppAgent(vppconfig, createOrUpdate)
+
 	if err != nil {
 		logrus.Errorf("Updating the VPP config failed with: %v", err)
 	}

--- a/pkg/universal-cnf/vppagent/backend.go
+++ b/pkg/universal-cnf/vppagent/backend.go
@@ -216,20 +216,13 @@ func (b *UniversalCNFVPPAgentBackend) GetEndpointIfID(serviceName string) string
 }
 
 // ProcessDPConfig applies the VPP CNF configuration to VPP
-func (b *UniversalCNFVPPAgentBackend) ProcessDPConfig(dpconfig interface{}, createOrUpdate bool) error {
+func (b *UniversalCNFVPPAgentBackend) ProcessDPConfig(dpconfig interface{}, update bool) error {
 	vppconfig, ok := dpconfig.(*vpp.ConfigData)
 	if !ok {
 		return fmt.Errorf("unable to convert dpconfig to vppconfig	")
 	}
 
-	if !createOrUpdate {
-		logrus.Println("[COSMIN] ProcessDPConfig. dpconfig: interfaces")
-		for _, inter := range vppconfig.Interfaces {
-			logrus.Println("[COSMIN] interface:", inter)
-		}
-	}
-
-	err := SendVppConfigToVppAgent(vppconfig, createOrUpdate)
+	err := SendVppConfigToVppAgent(vppconfig, update)
 
 	if err != nil {
 		logrus.Errorf("Updating the VPP config failed with: %v", err)

--- a/pkg/universal-cnf/vppagent/operations.go
+++ b/pkg/universal-cnf/vppagent/operations.go
@@ -66,11 +66,12 @@ func ResetVppAgent() error {
 	return nil
 }
 
-// SendVppConfigToVppAgent send the udpate to the VPP-Agent
+// SendVppConfigToVppAgent send the update to the VPP-Agent
 func SendVppConfigToVppAgent(vppconfig *vpp.ConfigData, update bool) error {
 	dataChange := &configurator.Config{
 		VppConfig: vppconfig,
 	}
+	logrus.Println("SEND_VPP_CALLED: with interfaces:", dataChange.VppConfig.Interfaces, "bool parameter", update)
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 
 	defer cancel()

--- a/pkg/universal-cnf/vppagent/operations.go
+++ b/pkg/universal-cnf/vppagent/operations.go
@@ -71,7 +71,7 @@ func SendVppConfigToVppAgent(vppconfig *vpp.ConfigData, update bool) error {
 	dataChange := &configurator.Config{
 		VppConfig: vppconfig,
 	}
-	logrus.Println("SEND_VPP_CALLED: with interfaces:", dataChange.VppConfig.Interfaces, "bool parameter", update)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 
 	defer cancel()


### PR DESCRIPTION
This PR add functionality for the removal of client facing interfaces when the ucnf connection close handler is called.


Closes: cisco-app-networking/cnns-prj#151