### PR TITLE
Feat: Improve ligato-vpp interface names.

### DIFF
--- a/cmd/vl3-nse/vl3_connect.go
+++ b/cmd/vl3-nse/vl3_connect.go
@@ -178,7 +178,7 @@ func (vxc *vL3ConnectComposite) Request(ctx context.Context,
 
 	if vl3SrcEndpointName, ok := conn.GetLabels()[LABEL_NSESOURCE]; ok {
 		// request is from another vl3 NSE
-		conn.Labels["ucnf/peerName"] = vl3SrcEndpointName
+		conn.Labels[config.PEER_NAME] = vl3SrcEndpointName
 		_ = vxc.processPeerRequest(vl3SrcEndpointName, request, request.Connection)
 
 	} else {

--- a/cmd/vl3-nse/vl3_connect.go
+++ b/cmd/vl3-nse/vl3_connect.go
@@ -178,6 +178,7 @@ func (vxc *vL3ConnectComposite) Request(ctx context.Context,
 
 	if vl3SrcEndpointName, ok := conn.GetLabels()[LABEL_NSESOURCE]; ok {
 		// request is from another vl3 NSE
+		conn.Labels["ucnf/peerName"] = vl3SrcEndpointName
 		_ = vxc.processPeerRequest(vl3SrcEndpointName, request, request.Connection)
 
 	} else {

--- a/deployments/helm/vl3/values.yaml
+++ b/deployments/helm/vl3/values.yaml
@@ -25,7 +25,7 @@ nsm:
   serviceName: vl3-service
 
 global:
-  
+
 replicaCount: 1
 
 image:

--- a/pkg/universal-cnf/config/config.go
+++ b/pkg/universal-cnf/config/config.go
@@ -29,6 +29,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	PEER_NAME = "ucnf/peerName"
+)
+
 // Command is a struct to describe exec.Command call arguments
 type Command struct {
 	Name string

--- a/pkg/universal-cnf/vppagent/backend.go
+++ b/pkg/universal-cnf/vppagent/backend.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cisco-app-networking/nsm-nse/pkg/universal-cnf/config"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/memif"
 	"github.com/sirupsen/logrus"
@@ -100,13 +101,13 @@ func (b *UniversalCNFVPPAgentBackend) ProcessClient(
 
 func (b *UniversalCNFVPPAgentBackend) buildVppIfName(defaultIfName, serviceName string, conn *connection.Connection) string {
 	// NSC peer connection
-	if name, ok := conn.Labels["podName"]; ok {
+	if name, ok := conn.Labels[connection.PodNameKey]; ok {
 		logrus.Infof("Setting ifName with podName: %s", name)
 		return name
 	}
 
 	// vl3 NSE peer connection
-	if name, ok := conn.Labels["ucnf/peerName"]; ok {
+	if name, ok := conn.Labels[config.PEER_NAME]; ok {
 		logrus.Infof("Setting ifName with vL3 peer name: %s", name)
 		return name
 	}


### PR DESCRIPTION
- Those changes imporve the names of the NSC or NSE peers, which is useful for debugging purposes. This work was initially started by @tiswanso .

Closes: cisco-app-networking/cnns-prj#226