### PR TITLE
vl3-nse changes to enable secure mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ e2e-kind-test: &e2e-kind-test
     - run:
         name: Run vl3 test
         command: |
-
           docker exec -e NSE_HUB=${ORG} -e NSE_TAG=${CIRCLE_SHA1} -t vl3-run bash -c "/go/run_vl3.sh"
     - run:
         name: Dump KinD Cluster state
@@ -167,7 +166,7 @@ jobs:
           name: Build ucnf-kiknos docker image
           working_directory: /go/src/github.com/cisco-app-networking/nsm-nse
           command: |
-            ORG=${ORG} TAG=${CIRCLE_SHA1} make docker-ucnf-kiknos-vppagent-build 
+            ORG=${ORG} TAG=${CIRCLE_SHA1} make docker-ucnf-kiknos-vppagent-build
       - run:
           name: Save docker images
           working_directory: /go/src/github.com/cisco-app-networking/nsm-nse

--- a/cmd/vl3-nse/service_registry.go
+++ b/cmd/vl3-nse/service_registry.go
@@ -40,10 +40,10 @@ func NewServiceRegistry(addr string, ctx context.Context) (ServiceRegistry, Serv
 	}
 
 	if !insecure && tools.GetConfig().SecurityProvider != nil {
-		if tlscfg, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx); err != nil {
+		if tlsConfig, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx); err != nil {
 			opts = append(opts, grpc.WithInsecure())
 		} else {
-			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlscfg)))
+			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		}
 	} else {
 		opts = append(opts, grpc.WithInsecure())

--- a/cmd/vl3-nse/service_registry.go
+++ b/cmd/vl3-nse/service_registry.go
@@ -34,18 +34,23 @@ func NewServiceRegistry(addr string, ctx context.Context) (ServiceRegistry, Serv
 
 	insecure, err := strconv.ParseBool(os.Getenv(tools.InsecureEnv))
 	if err != nil {
-		logrus.Error("Missing INSECURE env variable.")
-		logrus.Info("Continuing with insecure mode.")
+		logrus.Info("Missing INSECURE env variable. Continuing with insecure mode.")
 		insecure = true
 	}
 
 	if !insecure && tools.GetConfig().SecurityProvider != nil {
 		if tlsConfig, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx); err != nil {
+			logrus.Errorf(
+				"Failed getting tls config with error: %v. GRPC connection will be insecure.",
+				err,
+			)
 			opts = append(opts, grpc.WithInsecure())
 		} else {
+			logrus.Info("GRPC connection will be secured.")
 			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		}
 	} else {
+		logrus.Info("GRPC connection will be insecure.")
 		opts = append(opts, grpc.WithInsecure())
 	}
 

--- a/cmd/vl3-nse/service_registry.go
+++ b/cmd/vl3-nse/service_registry.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
+	"google.golang.org/grpc/credentials"
 	"strconv"
 	"strings"
 
@@ -23,9 +25,15 @@ const (
 
 type validationErrors []error
 
-func NewServiceRegistry(addr string) (ServiceRegistry, ServiceRegistryClient, error) {
+func NewServiceRegistry(addr string, ctx context.Context) (ServiceRegistry, ServiceRegistryClient, error) {
+	tlscfg, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx)
+	fmt.Println("[COSMIN]: TLSCONFIG", tlscfg)
+	if err != nil {
+		fmt.Println("[COSMIN]: could not get TLS configuration", err)
+		return nil, nil, err
+	}
 	conn, err := grpc.Dial(addr,
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(credentials.NewTLS(tlscfg)),
 		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
 	)

--- a/cmd/vl3-nse/service_registry.go
+++ b/cmd/vl3-nse/service_registry.go
@@ -27,9 +27,7 @@ type validationErrors []error
 
 func NewServiceRegistry(addr string, ctx context.Context) (ServiceRegistry, ServiceRegistryClient, error) {
 	tlscfg, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx)
-	fmt.Println("[COSMIN]: TLSCONFIG", tlscfg)
 	if err != nil {
-		fmt.Println("[COSMIN]: could not get TLS configuration", err)
 		return nil, nil, err
 	}
 	conn, err := grpc.Dial(addr,

--- a/cmd/vl3-nse/vl3_connect.go
+++ b/cmd/vl3-nse/vl3_connect.go
@@ -231,7 +231,7 @@ func (vxc *vL3ConnectComposite) Request(ctx context.Context,
 	if err != nil {
 		logger.Errorf("vL3 workload params not in labels: %v", err)
 	} else {
-		serviceRegistry, registryClient, err := NewServiceRegistry(vxc.nseControlAddr)
+		serviceRegistry, registryClient, err := NewServiceRegistry(vxc.nseControlAddr, ctx)
 		if err != nil {
 			logger.Error(err)
 		} else {
@@ -262,7 +262,7 @@ func (vxc *vL3ConnectComposite) Close(ctx context.Context, conn *connection.Conn
 		logrus.WithFields(logrus.Fields{
 			"SrcIP": processWorkloadIps(conn.Context.IpContext.SrcIpAddr, ";"),
 		}).Infof("vL3 Removing workload instance")
-		serviceRegistry, registryClient, err := NewServiceRegistry(vxc.nseControlAddr)
+		serviceRegistry, registryClient, err := NewServiceRegistry(vxc.nseControlAddr, ctx)
 		if err != nil {
 			logrus.Error(err)
 		} else {

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -26,7 +26,7 @@ spec:
       serviceAccount: {{ .Values.nsm.serviceName }}-acc
       containers:
         - name: vl3-nse
-          image: {{ .Values.registry }}/{{ .Values.org }}/vl3_ucnf-nse:{{ .Values.tag }}
+          image: {{ .Values.registry }}/cosminpetru/vl3_ucnf-nse:latest
           imagePullPolicy: {{ .Values.pullPolicy }}
           ports:
           - name: monitoring-vpp

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -151,3 +151,10 @@ spec:
       port: {{ .Values.metricsPort }}
       targetPort: monitoring
       protocol: TCP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.nsm.serviceName }}-acc
+  namespace: {{ .Release.Namespace }}
+

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -52,6 +52,8 @@ spec:
               value: "nsmgr.nsm-system"
             - name: NSREGISTRY_PORT
               value: "5000"
+            - name: INSECURE
+              value: "false"
 {{- if .Values.ipamUniqueOctet }}
             - name: NSE_IPAM_UNIQUE_OCTET
               value: {{ .Values.ipamUniqueOctet | quote }}

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -23,6 +23,7 @@ spec:
         wcm/nsr.port: {{ .Values.nseControl.nsr.port | quote }}
 {{- end }}
     spec:
+      serviceAccount: {{ .Values.nsm.serviceName }}-acc
       containers:
         - name: vl3-nse
           image: {{ .Values.registry }}/{{ .Values.org }}/vl3_ucnf-nse:{{ .Values.tag }}

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -26,7 +26,7 @@ spec:
       serviceAccount: {{ .Values.nsm.serviceName }}-acc
       containers:
         - name: vl3-nse
-          image: {{ .Values.registry }}/cosminpetru/vl3_ucnf-nse:latest
+          image: {{ .Values.registry }}/{{ .Values.org }}/vl3_ucnf-nse:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           ports:
           - name: monitoring-vpp
@@ -53,7 +53,7 @@ spec:
             - name: NSREGISTRY_PORT
               value: "5000"
             - name: INSECURE
-              value: "false"
+              value: {{ .Values.insecure }}
 {{- if .Values.ipamUniqueOctet }}
             - name: NSE_IPAM_UNIQUE_OCTET
               value: {{ .Values.ipamUniqueOctet | quote }}

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -53,7 +53,7 @@ spec:
             - name: NSREGISTRY_PORT
               value: "5000"
             - name: INSECURE
-              value: {{ .Values.insecure }}
+              value: "{{ .Values.insecure }}"
 {{- if .Values.ipamUniqueOctet }}
             - name: NSE_IPAM_UNIQUE_OCTET
               value: {{ .Values.ipamUniqueOctet | quote }}

--- a/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
+++ b/deployments/helm/vl3/templates/vl3-nse-ucnf.tpl
@@ -23,7 +23,7 @@ spec:
         wcm/nsr.port: {{ .Values.nseControl.nsr.port | quote }}
 {{- end }}
     spec:
-      serviceAccount: {{ .Values.nsm.serviceName }}-acc
+      serviceAccount: {{ .Values.nsm.serviceName }}-service-account
       containers:
         - name: vl3-nse
           image: {{ .Values.registry }}/{{ .Values.org }}/vl3_ucnf-nse:{{ .Values.tag }}
@@ -158,6 +158,6 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.nsm.serviceName }}-acc
+  name: {{ .Values.nsm.serviceName }}-service-account
   namespace: {{ .Release.Namespace }}
 

--- a/deployments/helm/vl3/values.yaml
+++ b/deployments/helm/vl3/values.yaml
@@ -8,14 +8,15 @@ tag: master
 pullPolicy: IfNotPresent
 vppMetricsPort: 9191
 metricsPort: 2112
+insecure: true
 
 nseControl:
   nsr:
     port: 5005
     addr: vl3-service.wcm-cisco.com
     cd: vl3-service-connectivity-domain
-# nameserver: 1.2.3.4
-# dnszone: cappnet-example.com
+  # nameserver: 1.2.3.4
+  # dnszone: cappnet-example.com
   ipam:
     defaultPrefixPool: 192.168.0.0/16
     prefixLength: 22

--- a/pkg/universal-cnf/config/config_ipam.go
+++ b/pkg/universal-cnf/config/config_ipam.go
@@ -111,7 +111,7 @@ func (es errors) Error() string {
 func NewIpamService(ctx context.Context, addr string) (IpamService, error) {
 	insecure, err := strconv.ParseBool(os.Getenv(tools.InsecureEnv))
 	if err != nil {
-		logrus.Error("Missing INSECURE env variable. Continuing with insecure mode enabled.")
+		logrus.Info("Missing INSECURE env variable. Continuing with insecure mode enabled.")
 		insecure = true
 	}
 
@@ -120,11 +120,17 @@ func NewIpamService(ctx context.Context, addr string) (IpamService, error) {
 	// If we have a service provider and we want to run in secure mode
 	if !insecure && tools.GetConfig().SecurityProvider != nil {
 		if tlsConfig, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx); err != nil {
+			logrus.Errorf(
+				"Failed getting tls config with error: %v. GRPC connection will be insecure.",
+				err,
+			)
 			opts = append(opts, grpc.WithInsecure())
 		} else {
+			logrus.Info("GRPC connection will be secured.")
 			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		}
 	} else {
+		logrus.Info("GRPC connection will be insecure.")
 		opts = append(opts, grpc.WithInsecure())
 	}
 

--- a/pkg/universal-cnf/config/config_ipam.go
+++ b/pkg/universal-cnf/config/config_ipam.go
@@ -117,14 +117,15 @@ func NewIpamService(ctx context.Context, addr string) (IpamService, error) {
 
 	var opts []grpc.DialOption
 
-	if insecure {
-		opts = append(opts, grpc.WithInsecure())
-	} else {
+	// If we have a service provider and we want to run in secure mode
+	if !insecure && tools.GetConfig().SecurityProvider != nil {
 		if tlsConfig, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx); err != nil {
 			opts = append(opts, grpc.WithInsecure())
 		} else {
 			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		}
+	} else {
+		opts = append(opts, grpc.WithInsecure())
 	}
 
 	conn, err := grpc.Dial(addr, opts...)

--- a/pkg/universal-cnf/config/config_ipam.go
+++ b/pkg/universal-cnf/config/config_ipam.go
@@ -120,12 +120,11 @@ func NewIpamService(ctx context.Context, addr string) (IpamService, error) {
 	if insecure {
 		opts = append(opts, grpc.WithInsecure())
 	} else {
-		tlsConfig, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx)
-		if err != nil {
-			logrus.Error("Could not get TLS configuration")
-			return nil, err
+		if tlsConfig, err := tools.GetConfig().SecurityProvider.GetTLSConfig(ctx); err != nil {
+			opts = append(opts, grpc.WithInsecure())
+		} else {
+			opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		}
-		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	}
 
 	conn, err := grpc.Dial(addr, opts...)

--- a/pkg/universal-cnf/config/config_ipam.go
+++ b/pkg/universal-cnf/config/config_ipam.go
@@ -18,10 +18,6 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-const (
-	insecureEnvVar = "INSECURE"
-)
-
 type IpamService interface {
 	AllocateSubnet(ucnfEndpoint *nseconfig.Endpoint) (string, error)
 }
@@ -113,7 +109,7 @@ func (es errors) Error() string {
 }
 
 func NewIpamService(ctx context.Context, addr string) (IpamService, error) {
-	insecure, err := strconv.ParseBool(os.Getenv(insecureEnvVar))
+	insecure, err := strconv.ParseBool(os.Getenv(tools.InsecureEnv))
 	if err != nil {
 		logrus.Error("Missing INSECURE env variable. Continuing with insecure mode enabled.")
 		insecure = true

--- a/scripts/vl3/nsm_install_interdomain.sh
+++ b/scripts/vl3/nsm_install_interdomain.sh
@@ -27,7 +27,7 @@ case $i in
     NSM_TAG="${i#*=}"
     ;;
     --spire-disabled)
-    SPIRE_DISABLED="true"
+    SPIRE_DISABLED="false"
     ;;
     -h|--help)
       print_usage
@@ -91,9 +91,10 @@ helm template ${NSMDIR}/deployments/helm/nsm \
   --set org=${NSM_HUB},tag=${NSM_TAG} \
   --set admission-webhook.org=${NSM_HUB},admission-webhook.tag=${NSM_TAG} \
   --set pullPolicy=Always \
+  --set selfSignedCA="false" \
   --set insecure="true" \
   --set global.JaegerTracing="true" \
-  ${SPIRE_DISABLED:+--set spire.enabled=false} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
+  --set spire.enabled="true"| kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 print_header "NSM-addons"
 helm template ${VL3DIR}/deployments/helm/nsm-addons \

--- a/scripts/vl3/nsm_install_interdomain.sh
+++ b/scripts/vl3/nsm_install_interdomain.sh
@@ -65,20 +65,20 @@ fi
 print_header "Crossconnect Monitor"
 helm template ${NSMDIR}/deployments/helm/crossconnect-monitor \
   --namespace nsm-system \
-  --set insecure="true" \
+  --set insecure="false" \
   --set global.JaegerTracing="true" | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 print_header "Jaeger"
 helm template ${NSMDIR}/deployments/helm/jaeger \
   --namespace nsm-system \
-  --set insecure="true" \
+  --set insecure="false" \
   --set global.JaegerTracing="true" \
   --set monSvcType=NodePort | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 print_header "Skydive"
 helm template ${NSMDIR}/deployments/helm/skydive \
   --namespace nsm-system \
-  --set insecure="true" \
+  --set insecure="false" \
   --set global.JaegerTracing="true" | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 
@@ -109,7 +109,7 @@ helm template ${NSMDIR}/deployments/helm/proxy-nsmgr \
   --namespace nsm-system \
   --set org=${NSM_HUB},tag=${NSM_TAG} \
   --set pullPolicy=Always \
-  --set insecure="true" \
+  --set insecure="false" \
   --set global.JaegerTracing="true" \
   ${REMOTE_NSR_PORT:+ --set remoteNsrPort=${REMOTE_NSR_PORT}} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 

--- a/scripts/vl3/nsm_install_interdomain.sh
+++ b/scripts/vl3/nsm_install_interdomain.sh
@@ -29,7 +29,7 @@ case $i in
     NSM_TAG="${i#*=}"
     ;;
     --spire-disabled)
-    SPIRE_DISABLED="false"
+    SPIRE_DISABLED="true"
     ;;
     --secure)
     INSECURE=false

--- a/scripts/vl3/nsm_install_interdomain.sh
+++ b/scripts/vl3/nsm_install_interdomain.sh
@@ -49,20 +49,6 @@ function print_header() {
     fi
 }
 
-function generate_certs() {
-    if [ ! -x "$(command -v openssl)" ]; then
-        echo "openssl not found"
-        exit 1
-    fi
-
-    certs_location="${NSMDIR}/deployments/helm/nsm"
-
-    echo "creating certs in ${certs_location}"
-
-    openssl req -x509 -newkey rsa:4096 -keyout "${certs_location}/charts/spire/key.pem" -out "${certs_location}/charts/spire/cert.pem" -days 365 -nodes -subj '/CN=localhost'
-    echo "Certificates have been created."
-}
-
 sdir=$(dirname ${0})
 
 NSMDIR=${NSMDIR:-${GOPATH}/src/github.com/cisco-app-networking/networkservicemesh}
@@ -98,10 +84,6 @@ helm template ${NSMDIR}/deployments/helm/skydive \
 
 # kubednsip=$(kubectl get svc -n kube-system ${KCONF:+--kubeconfig $KCONF} | grep kube-dns | awk '{ print $3 }')
 # kinddnsip=$(kubectl get svc ${KCONF:+--kubeconfig $KCONF} | grep kind-dns | awk '{ print $3 }')
-
-print_header "Generating certificates"
-generate_certs
-print_header "Certificates have been generated"
 
 print_header "NSM"
 helm template ${NSMDIR}/deployments/helm/nsm \

--- a/scripts/vl3/nsm_install_interdomain.sh
+++ b/scripts/vl3/nsm_install_interdomain.sh
@@ -10,12 +10,14 @@ Options:
   --nsm-tag=STRING          Tag for NSM images
                             (default=\"vl3_api_rebase\", environment variable: NSM_TAG)
   --spire-disabled          Disable spire
+  --secure                  Make NSM components run in secure mode.
 " >&2
 }
 
 NSM_HUB="${NSM_HUB:-"ciscoappnetworking"}"
 NSM_TAG="${NSM_TAG:-"vl3_latest"}"
 INSTALL_OP=${INSTALL_OP:-apply}
+INSECURE=${INSECURE:-true}
 
 for i in "$@"
 do
@@ -28,6 +30,9 @@ case $i in
     ;;
     --spire-disabled)
     SPIRE_DISABLED="false"
+    ;;
+    --secure)
+    INSECURE=false
     ;;
     -h|--help)
       print_usage
@@ -65,20 +70,20 @@ fi
 print_header "Crossconnect Monitor"
 helm template ${NSMDIR}/deployments/helm/crossconnect-monitor \
   --namespace nsm-system \
-  --set insecure="false" \
+  --set insecure=${INSECURE} \
   --set global.JaegerTracing="true" | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 print_header "Jaeger"
 helm template ${NSMDIR}/deployments/helm/jaeger \
   --namespace nsm-system \
-  --set insecure="false" \
+  --set insecure=${INSECURE} \
   --set global.JaegerTracing="true" \
   --set monSvcType=NodePort | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 print_header "Skydive"
 helm template ${NSMDIR}/deployments/helm/skydive \
   --namespace nsm-system \
-  --set insecure="false" \
+  --set insecure=${INSECURE} \
   --set global.JaegerTracing="true" | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 
@@ -92,9 +97,9 @@ helm template ${NSMDIR}/deployments/helm/nsm \
   --set admission-webhook.org=${NSM_HUB},admission-webhook.tag=${NSM_TAG} \
   --set pullPolicy=Always \
   --set spire.selfSignedCA="false" \
-  --set insecure="false" \
+  --set insecure=${INSECURE} \
   --set global.JaegerTracing="true" \
-  --set spire.enabled="true"| kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
+  ${SPIRE_DISABLED:+--set spire.enabled=false} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 
 print_header "NSM-addons"
 helm template ${VL3DIR}/deployments/helm/nsm-addons \
@@ -109,7 +114,7 @@ helm template ${NSMDIR}/deployments/helm/proxy-nsmgr \
   --namespace nsm-system \
   --set org=${NSM_HUB},tag=${NSM_TAG} \
   --set pullPolicy=Always \
-  --set insecure="false" \
+  --set insecure=${INSECURE} \
   --set global.JaegerTracing="true" \
   ${REMOTE_NSR_PORT:+ --set remoteNsrPort=${REMOTE_NSR_PORT}} | kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 

--- a/scripts/vl3/nsm_install_interdomain.sh
+++ b/scripts/vl3/nsm_install_interdomain.sh
@@ -92,7 +92,7 @@ helm template ${NSMDIR}/deployments/helm/nsm \
   --set admission-webhook.org=${NSM_HUB},admission-webhook.tag=${NSM_TAG} \
   --set pullPolicy=Always \
   --set spire.selfSignedCA="false" \
-  --set insecure="true" \
+  --set insecure="false" \
   --set global.JaegerTracing="true" \
   --set spire.enabled="true"| kubectl ${INSTALL_OP} ${KCONF:+--kubeconfig $KCONF} -f -
 


### PR DESCRIPTION
Service registry, and IPAM  connections can now be (depending on the ``INSECURE`` env variable) **secure** or **insecure**.


Consistency changes: Modified ``vl3-nse-ucnf.tpl`` so that it matches the operator.  

Closes: cisco-app-networking/cnns-prj#11 