### PR TITLE
Include cnf-vppagent binary in supervisor init hook

### DIFF
--- a/build/nse/ucnf-kiknos/vppagent/Dockerfile
+++ b/build/nse/ucnf-kiknos/vppagent/Dockerfile
@@ -16,7 +16,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bi
 FROM ${VPP_AGENT} as runtime
 COPY --from=build /go/bin/cnf-vppagent /bin/cnf-vppagent
 COPY ./build/nse/universal-cnf/vppagent/etc/ /etc/
-COPY ./build/nse/universal-cnf/vppagent/etc/supervisord/supervisord.conf /opt/vpp-agent/dev/supervisor.conf
+COPY ./build/nse/ucnf-kiknos/vppagent/etc/supervisord/supervisord.conf /opt/aio-agent/dev/supervisor.conf
+COPY ./build/nse/ucnf-kiknos/vppagent/etc/supervisord/init_hook.sh /usr/bin/init_hook.sh
 RUN set -ex; \
     rm /opt/aio-agent/dev/etcd.conf; \
     echo 'endpoint: "localhost:9113"' > /opt/aio-agent/dev/grpc.conf ; \

--- a/build/nse/ucnf-kiknos/vppagent/etc/supervisord/init_hook.sh
+++ b/build/nse/ucnf-kiknos/vppagent/etc/supervisord/init_hook.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+terminate_process () {
+    PID=$(pidof $1)
+    if [[ ${PID} != "" ]]; then
+        kill ${PID}
+        echo "process $1 terminated"
+    fi
+}
+
+if [[ "${SUPERVISOR_PROCESS_NAME}" = "vpp" && "${SUPERVISOR_PROCESS_STATE}" = "terminated" ]]; then
+    terminate_process vpp-agent-init
+fi
+
+if [[ "${SUPERVISOR_PROCESS_NAME}" = "aio-agent" && "${SUPERVISOR_PROCESS_STATE}" = "terminated" ]]; then
+    terminate_process vpp-agent-init
+fi
+
+if [[ "${SUPERVISOR_PROCESS_NAME}" = "strongswan" && "${SUPERVISOR_PROCESS_STATE}" = "terminated" ]]; then
+    terminate_process vpp-agent-init
+fi
+
+if [[ "${SUPERVISOR_PROCESS_NAME}" = "cnf" && "${SUPERVISOR_PROCESS_STATE}" = "terminated" ]]; then
+    terminate_process vpp-agent-init
+fi

--- a/build/nse/ucnf-kiknos/vppagent/etc/supervisord/supervisord.conf
+++ b/build/nse/ucnf-kiknos/vppagent/etc/supervisord/supervisord.conf
@@ -1,0 +1,15 @@
+programs:
+  - name: "vpp"
+    executable-path: "/usr/bin/vpp"
+    executable-args: ["-c", "/etc/vpp/vpp.conf"]
+  - name: "aio-agent"
+    executable-path: "/usr/bin/aio-sswan-agent"
+    executable-args: ["--config-dir=/opt/aio-agent/dev"]
+  - name: "strongswan"
+    executable-path: "/usr/local/libexec/ipsec/charon"
+    executable-args: ["--use-syslog"]
+  - name: "cnf"
+    executable-path: "/bin/cnf-vppagent"
+    executable-args: []
+hooks:
+  - cmd: "/usr/bin/init_hook.sh"

--- a/build/nse/universal-cnf/vppagent/etc/supervisord/init_hook.sh
+++ b/build/nse/universal-cnf/vppagent/etc/supervisord/init_hook.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+terminate_process () {
+    PID=$(pidof $1)
+    if [[ ${PID} != "" ]]; then
+        kill ${PID}
+        echo "process $1 terminated"
+    fi
+}
+
+if [[ "${SUPERVISOR_PROCESS_NAME}" = "vpp" && "${SUPERVISOR_PROCESS_STATE}" = "terminated" ]]; then
+    terminate_process vpp-agent-init
+fi
+
+if [[ "${SUPERVISOR_PROCESS_NAME}" = "agent" && "${SUPERVISOR_PROCESS_STATE}" = "terminated" ]]; then
+    terminate_process vpp-agent-init
+fi
+
+if [[ "${SUPERVISOR_PROCESS_NAME}" = "cnf" && "${SUPERVISOR_PROCESS_STATE}" = "terminated" ]]; then
+    terminate_process vpp-agent-init
+fi

--- a/build/nse/vl3-nse/Dockerfile.no_go_build_ucnf
+++ b/build/nse/vl3-nse/Dockerfile.no_go_build_ucnf
@@ -14,3 +14,4 @@ COPY vl3_nse /bin/cnf-vppagent
 
 COPY etc/ /etc/
 COPY etc/supervisord/supervisord.conf /opt/vpp-agent/dev/supervisor.conf
+COPY etc/supervisord/init_hook.sh /usr/bin/init_hook.sh


### PR DESCRIPTION
Related to https://github.com/cisco-app-networking/cnns-prj/issues/119

The NSE docker image uses a supervisor process as the main process in the container, which spawns 3 child processes - `cnf-vppagent` (the NSE binary). `vpp-agent` (Ligato VPP Agent bianry) and `vpp`. The supervisor uses an init hook to detect termination of these child processes, and kills the main process upon termination of any of them.

Up till now, the `cnf-vppagent` binary wasn't included in the init hook (since the NSE image was using the hook from the parent Ligato image). As a result of that, if the NSE binary (`cnf-vppagent`) crashed, the NSE pod stayed up and was still considered healthy by k8s.

This PR adds an init hook that overrides the one from the parent Ligato image and handles `cnf-vppagent` crash properly by killing the pod:

```
$ kubectl exec -it vl3-nse-bar-7c9dbbbd79-jzzlr -n wcm-system -- bash
root@vl3-nse-bar-7c9dbbbd79-jzzlr:~# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.1  0.0 925692  7160 ?        Ssl  12:16   0:00 vpp-agent-init
root          17  1.5  1.1 18310392 97444 ?      S    12:16   0:01 /usr/bin/vpp -c /etc/vpp/vpp.conf
root          18  0.2  0.4 1165988 34880 ?       Sl   12:16   0:00 /bin/vpp-agent --config-dir=/opt/vpp-agent/dev
root          20  0.0  0.1 718852 15444 ?        SLl  12:16   0:00 /bin/cnf-vppagent
root          61  0.0  0.0  18504  3452 pts/0    Ss   12:17   0:00 bash
root          77  0.0  0.0  34404  2836 pts/0    R+   12:17   0:00 ps aux
root@vl3-nse-bar-7c9dbbbd79-jzzlr:~# 
root@vl3-nse-bar-7c9dbbbd79-jzzlr:~# 
root@vl3-nse-bar-7c9dbbbd79-jzzlr:~# kill -9 20
root@vl3-nse-bar-7c9dbbbd79-jzzlr:~# command terminated with exit code 137
```