### PR TITLE
Fix ci-runner build for PR triggers

### DIFF
--- a/build/ci/runner/Dockerfile.runner
+++ b/build/ci/runner/Dockerfile.runner
@@ -9,7 +9,8 @@ ARG  nsm_branch=vl3_latest
 
 RUN  git clone $vl3_repo /go/src/github.com/cisco-app-networking/nsm-nse && \
      cd /go/src/github.com/cisco-app-networking/nsm-nse && \
-     git checkout $vl3_branch
+     git fetch origin $vl3_branch:test_branch && \
+     git checkout test_branch
 
 RUN  git clone $nsm_repo /go/src/github.com/cisco-app-networking/networkservicemesh && \
      cd /go/src/github.com/cisco-app-networking/networkservicemesh && \


### PR DESCRIPTION
git fetch && git checkout method should cover branch and SHA checkout scenarios, even from PR