### PR TITLE
add ci jenkins pipeline for vpp e2e tests 

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,0 +1,40 @@
+docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/run/docker.sock') {
+    environment{
+        CGO_ENABLED = 0
+        GO111MODULE = on
+    }
+    stage ('Install Docker Client') {
+        sh "apt-get update"
+        sh '''
+           apt-get install -y \
+           apt-transport-https \
+           ca-certificates \
+           curl \
+           gnupg-agent \
+           software-properties-common
+        '''
+        sh "curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -"
+        sh '''
+           add-apt-repository \
+           "deb [arch=amd64] https://download.docker.com/linux/debian \
+           $(lsb_release -cs) \
+           stable"
+        '''
+        sh "apt-get update && apt-get install -y docker-ce-cli"
+    }
+    stage ('Checkout SCM') {
+        checkout scm
+    }
+    stage ('Go Test Environment Variables') {
+        suffix="-${env.JOB_NAME}-${currentBuild.number}".toLowerCase().replaceAll("[^a-z0-9]","_")
+        sh "echo ${suffix}\n" +
+           "export PATH=$PATH:/usr/local/go/bin\n" +
+           "export NSMNSE_E2E_TEST_IMG=e2e-img${suffix}\n" +
+           "export NSMNSE_E2E_TEST_NAME=e2e-name${suffix}\n" +
+           "./test/e2e/run_e2e.sh\n"
+    }
+    stage ('Clean Up') {
+        deleteDir()
+    }
+}
+

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,3 +1,4 @@
+//The Jenkinsfile runs entire build in a golang container and mounts the /var/run/docker.sock file to allow access to the host docker within the container
 docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/run/docker.sock') {
     environment{
         CGO_ENABLED = 0
@@ -32,9 +33,6 @@ docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/
            "export NSMNSE_E2E_TEST_IMG=e2e-img${suffix}\n" +
            "export NSMNSE_E2E_TEST_NAME=e2e-name${suffix}\n" +
            "./test/e2e/run_e2e.sh\n"
-    }
-    stage ('Clean Up') {
-        deleteDir()
     }
 }
 

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -5,8 +5,8 @@ echo "Preparing vpp-agent end-to-end tests.."
 
 args=($*)
 VPP_IMG="${VPP_IMG:-ligato/vpp-base}"
-testname="vpp-agent-e2e-test"
-imgname="vpp-agent-e2e-tests"
+testname="${NSMNSE_E2E_TEST_NAME:-vpp-agent-e2e-test}"
+imgname="${NSMNSE_E2E_TEST_IMG:-vpp-agent-e2e-tests}"
 
 # Compile vpp-agent for testing
 go build -o ./test/e2e/vpp-agent.test \
@@ -36,10 +36,9 @@ docker build \
 vppver=$(docker run --rm -i "$VPP_IMG" dpkg-query -f '${Version}' -W vpp)
 
 cleanup() {
-	echo "stopping test container"
+  echo "Removing the image.."
 	set -x
-	docker stop -t 1 "${testname}" 2>/dev/null
-	docker rm -v "${testname}" 2>/dev/null
+	docker image rm "${imgname}" 2>/dev/null
 }
 
 trap 'cleanup' EXIT
@@ -51,6 +50,7 @@ echo "============================================================="
 # Run e2e tests
 if docker run -i \
 	--name "${testname}" \
+	--rm \
 	--pid=host \
 	--privileged \
 	--label io.ligato.vpp-agent.testsuite=e2e \
@@ -71,3 +71,4 @@ else
 	echo >&2 "-------------------------------------------------------------"
 	exit $res
 fi
+


### PR DESCRIPTION
#### This is the PR for [NSM-NSE80](https://jira-eng-sjc4.cisco.com/jira/browse/NSMNSE-80).  
  
The Jenkinsfile runs entire build in a golang container and mounts the /var/run/docker.sock file to allow access to the host docker within the container. The container will exit after all stages finish running.

Inside of **run_e2e.sh**,  container name and image name are parameterized so that the names can be passed in as a combination of **job_name** and the **current_build_number**.  This avoids different Jenkins jobs using the same container name and image name on the builds. A few lines were added to remove the test images for further clean up.
   

> Console output: [updated link](https://engci-private-sjc.cisco.com/jenkins/eti-sre/job/AppN/job/wcm/job/nsm-nse/job/devops-origin-test/71/console)