### PR TITLE
update ci jenkins pipeline for latest version VPP integration tests

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -26,7 +26,7 @@ docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/
     stage ('Checkout SCM') {
         checkout scm
     }
-    stage ('Go Test Environment Variables') {
+    stage ('VPP Integration Test') {
         suffix="-${env.JOB_NAME}-${currentBuild.number}".toLowerCase().replaceAll("[^a-z0-9]","_")
         sh "echo ${suffix}\n" +
            "export PATH=$PATH:/usr/local/go/bin\n" +

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,4 +1,4 @@
-//The Jenkinsfile runs entire build in a golang container and mounts the /var/run/docker.sock file to allow access to the host docker within the container
+//The Jenkinsfile runs entire build in golang container and mounts the /var/run/docker.sock file to allow access to the host docker within the container
 docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/run/docker.sock') {
     environment{
         CGO_ENABLED = 0

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -35,3 +35,4 @@ docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/
            "./test/integration/run.sh\n"
     }
 }
+

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,4 +1,4 @@
-//The Jenkinsfile runs entire build in golang container and mounts the /var/run/docker.sock file to allow access to the host docker within the container
+//The Jenkinsfile runs entire build in a golang container and mounts the /var/run/docker.sock file to allow access to the host docker within the container
 docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/run/docker.sock') {
     environment{
         CGO_ENABLED = 0
@@ -28,6 +28,7 @@ docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/
     }
     stage ('VPP Integration Test') {
         suffix="-${env.JOB_NAME}-${currentBuild.number}".toLowerCase().replaceAll("[^a-z0-9]","_")
+        sh "docker pull busybox:1.31"
         sh "echo ${suffix}\n" +
            "export PATH=$PATH:/usr/local/go/bin\n" +
            "export NSMNSE_E2E_TEST_IMG=e2e-img${suffix}\n" +

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,0 +1,37 @@
+//The Jenkinsfile runs entire build in a golang container and mounts the /var/run/docker.sock file to allow access to the host docker within the container
+docker.image('golang:1.15-buster').inside('-u root -v /var/run/docker.sock:/var/run/docker.sock') {
+    environment{
+        CGO_ENABLED = 0
+        GO111MODULE = on
+    }
+    stage ('Install Docker Client') {
+        sh "apt-get update"
+        sh '''
+           apt-get install -y \
+           apt-transport-https \
+           ca-certificates \
+           curl \
+           gnupg-agent \
+           software-properties-common
+        '''
+        sh "curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -"
+        sh '''
+           add-apt-repository \
+           "deb [arch=amd64] https://download.docker.com/linux/debian \
+           $(lsb_release -cs) \
+           stable"
+        '''
+        sh "apt-get update && apt-get install -y docker-ce-cli"
+    }
+    stage ('Checkout SCM') {
+        checkout scm
+    }
+    stage ('Go Test Environment Variables') {
+        suffix="-${env.JOB_NAME}-${currentBuild.number}".toLowerCase().replaceAll("[^a-z0-9]","_")
+        sh "echo ${suffix}\n" +
+           "export PATH=$PATH:/usr/local/go/bin\n" +
+           "export NSMNSE_E2E_TEST_IMG=e2e-img${suffix}\n" +
+           "export NSMNSE_E2E_TEST_NAME=e2e-name${suffix}\n" +
+           "./test/integration/run.sh\n"
+    }
+}


### PR DESCRIPTION
#### This is the PR for [NSM-NSE80](https://jira-eng-sjc4.cisco.com/jira/browse/NSMNSE-80).  
  
- **Description**: The Jenkinsfile runs entire build in a golang container and mounts the /var/run/docker.sock file to allow access to the host docker within the container. The container will exit after all stages finish running.

- **Update**: I modified the script from executing shell command **./test/e2e/run_e2e.sh** to **./test/integration/run.sh** . Also succesfully run the scripts on the latest AppN cisco-app-networking Jenkins [(link)](https://engci-private-sjc.cisco.com/jenkins/eti-sre/job/AppN/job/cisco-app-networking/). 

- **Console Output**: [updated link](https://engci-private-sjc.cisco.com/jenkins/eti-sre/job/AppN/job/cisco-app-networking/job/nsm-nse/job/devop_jenkins/19/console)